### PR TITLE
Bugfix aep

### DIFF
--- a/eva.py
+++ b/eva.py
@@ -151,12 +151,7 @@ def ari_to_aep(ari):
 def aep_to_quantile(aep, mode):
     """Annual exceedance probability to quantile"""
     
-    if mode == 'max':
-        quantile = 1 - (1. / aep_to_ari(aep))
-    elif mode == 'min':
-        quantile = 1. / aep_to_ari(aep)
-    else:
-        raise ValueError('Invalid mode')
+    quantile = ari_to_quantile(aep_to_ari(aep), mode)
     
     return quantile
 

--- a/eva.py
+++ b/eva.py
@@ -136,16 +136,25 @@ def single2list(item, numpy_array=False):
 
     return output
 
+
 def aep_to_ari(aep):
-    """Convert from aep (%) to ari (years)"""
+    """Convert from aep (%) to ari (years)
+    
+    Details: http://www.bom.gov.au/water/designRainfalls/ifd-arr87/glossary.shtml
+    """
+    
     assert aep < 100, "aep to be expressed as a percentage (must be < 100)"
     aep = aep/100
-    return 1/(-np.log(1-aep))
+    
+    return 1 / (-np.log(1-aep))
 
 
 def ari_to_aep(ari):
-    """Convert from ari (years) to aep (%)"""
-    return ((np.exp(1/ari) - 1)/np.exp(1/ari)) * 100
+    """Convert from ari (years) to aep (%)
+    
+    Details: http://www.bom.gov.au/water/designRainfalls/ifd-arr87/glossary.shtml
+    """
+    return ((np.exp(1/ari) - 1) / np.exp(1/ari)) * 100
 
 
 def aep_to_quantile(aep, mode):

--- a/eva.py
+++ b/eva.py
@@ -136,14 +136,26 @@ def single2list(item, numpy_array=False):
 
     return output
 
+def aep_to_ari(aep):
+    """Convert from aep (%) to ari (years)"""
+    assert aep >= 1, "aep to be expressed as an integer percentage (1-99)"
+    assert aep < 100, "aep to be expressed as an integer percentage (1-99)"
+    aep = aep/100
+    return 1/(-np.log(1-aep))
+
+
+def ari_to_aep(ari):
+    """Convert from ari (years) to aep (%)"""
+    return ((np.exp(1/ari) - 1)/np.exp(1/ari)) * 100
+
 
 def aep_to_quantile(aep, mode):
     """Annual exceedance probability to quantile"""
-
+    
     if mode == 'max':
-        quantile =  1 - (aep / 100.)
+        quantile = 1 - (1. / aep_to_ari(aep))
     elif mode == 'min':
-        quantile = aep / 100.
+        quantile = 1. / aep_to_ari(aep)
     else:
         raise ValueError('Invalid mode')
     

--- a/eva.py
+++ b/eva.py
@@ -138,8 +138,7 @@ def single2list(item, numpy_array=False):
 
 def aep_to_ari(aep):
     """Convert from aep (%) to ari (years)"""
-    assert aep >= 1, "aep to be expressed as an integer percentage (1-99)"
-    assert aep < 100, "aep to be expressed as an integer percentage (1-99)"
+    assert aep < 100, "aep to be expressed as a percentage (must be < 100)"
     aep = aep/100
     return 1/(-np.log(1-aep))
 


### PR DESCRIPTION
I applied a fix for the incorrect AEP calculations (fixes #12).

Information on the differences between ARI and AEP and how they are related can be seen at the ARR page hosted by BoM: http://www.bom.gov.au/water/designRainfalls/ifd-arr87/glossary.shtml

I have tested the fix and reproduced the AEP values from AGCD 1981-2010 created using my R code to within 1e-5, so I'm happy that they are the same to within approx. floating point precision.